### PR TITLE
Calling .bind() is required even when doing an anonymous bind.

### DIFF
--- a/radicale_auth_ldap/__init__.py
+++ b/radicale_auth_ldap/__init__.py
@@ -47,9 +47,9 @@ class Auth(BaseAuth):
         
         if BINDDN and PASSWORD:
             conn = ldap3.Connection(SERVER, BINDDN, PASSWORD)
-            conn.bind()
         else:
             conn = ldap3.Connection(SERVER)
+        conn.bind()
 
         try:
             self.logger.debug("LDAP whoami: %s" % conn.extend.standard.who_am_i())


### PR DESCRIPTION
Otherwise you get the following error when trying to authenticate using an anonymous bind to query the list of users:

```
7fba2e8f8700] ERROR: An exception occurred during GET request on '/.web/': unable to send message, socket is not open
Traceback (most recent call last):
  File "/nix/store/9qrp72pjhhzpsc50xyc2kqz8bh3ywf55-python3-3.6.4-env/lib/python3.6/site-packages/radicale/__init__.py", line 321, in __call__
    status, headers, answers = self._handle_request(environ)
  File "/nix/store/9qrp72pjhhzpsc50xyc2kqz8bh3ywf55-python3-3.6.4-env/lib/python3.6/site-packages/radicale/__init__.py", line 450, in _handle_request
    password)
  File "/nix/store/9qrp72pjhhzpsc50xyc2kqz8bh3ywf55-python3-3.6.4-env/lib/python3.6/site-packages/radicale/auth.py", line 115, in is_authenticated2
    return self.is_authenticated(user, password)
  File "/nix/store/9qrp72pjhhzpsc50xyc2kqz8bh3ywf55-python3-3.6.4-env/lib/python3.6/site-packages/radicale_auth_ldap/__init__.py", line 71, in is_authenticated
    attributes=[ATTRIBUTE])
  File "/nix/store/9qrp72pjhhzpsc50xyc2kqz8bh3ywf55-python3-3.6.4-env/lib/python3.6/site-packages/ldap3/core/connection.py", line 765, in search
    response = self.post_send_search(self.send('searchRequest', request, controls))
  File "/nix/store/9qrp72pjhhzpsc50xyc2kqz8bh3ywf55-python3-3.6.4-env/lib/python3.6/site-packages/ldap3/strategy/base.py", line 307, in send
    raise LDAPSocketOpenError(self.connection.last_error)
ldap3.core.exceptions.LDAPSocketOpenError: unable to send message, socket is not open
^C[7fba3c37ab40] INFO: Stopping Radicale
```