### PR TITLE
Add ldap_support_extended configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,4 +31,8 @@ ldap_password = verysecurepassword
 
 # LDAP scope of the search
 ldap_scope = LEVEL
+
+# LDAP extended option
+# If the server is samba, ldap_support_extended is should be no
+ldap_support_extended = yes
 ```

--- a/radicale_auth_ldap/__init__.py
+++ b/radicale_auth_ldap/__init__.py
@@ -44,6 +44,7 @@ class Auth(BaseAuth):
         BINDDN = self.configuration.get("auth", "ldap_binddn")
         PASSWORD = self.configuration.get("auth", "ldap_password")
         SCOPE = self.configuration.get("auth", "ldap_scope")
+        SUPPORT_EXTENDED = self.configuration.getboolean("auth", "ldap_support_extended", fallback=True)
         
         if BINDDN and PASSWORD:
             conn = ldap3.Connection(SERVER, BINDDN, PASSWORD)
@@ -80,8 +81,12 @@ class Auth(BaseAuth):
                 conn = ldap3.Connection(SERVER, user_dn, password)
                 conn.bind()
                 self.logger.debug(conn.result)
-                whoami = conn.extend.standard.who_am_i()
-                self.logger.debug("LDAP whoami: %s" % whoami)
+                if SUPPORT_EXTENDED:
+                    whoami = conn.extend.standard.who_am_i()
+                    self.logger.debug("LDAP whoami: %s" % whoami)
+                else:
+                    self.logger.debug("LDAP skip extended: call whoami")
+                    whoami = conn.result['result'] == 0
                 if whoami:
                     self.logger.debug("LDAP bind OK")
                     return True


### PR DESCRIPTION
* Add ldap_support_extended configuration

For samba, extended command is not supported.
To solve, add configuration to call whoami or not.

```
DEBUG:ldap3:EXTENDED:ldap message received via <ldaps://samba:636 - ssl - user: CN=test2,CN=Users,DC=samba,DC=dom - not lazy - bound - open - <local: 172.18.0.0:33916 - remote: 172.18.0.0:636> - tls not started - listening - SyncStrategy - internal decoder>:
<<{'controls': None,
<< 'messageID': 9,
<< 'payload': [(0, False, 10, 2),
<<             (0, False, 4, b''),
<<             (0,
<<              False,
<<              4,
<<              b'Extended Operation(1.3.6.1.4.1.4203.1.11.3) not supported'),
<<             (2, False, 10, b'1.3.6.1.4.1.4203.1.11.3')],
<< 'protocolOp': 24}
DEBUG:ldap3:PROTOCOL:EXTENDED response <[{'result': 2, 'description': 'protocolError', 'dn': '', 'message': 'Extended Operation(1.3.6.1.4.1.4203.1.11.3) not supported', 'referrals': None, 'responseName': '1.3.6.1.4.1.4203.1.11.3', 'responseValue': b'', 'type': 'extendedResp'}]> received via <ldaps://samba:636 - ssl - user: CN=test2,CN=Users,DC=samba,DC=dom - not lazy - bound - open - <local: 172.18.0.0:33916 - remote: 172.18.0.0:636> - tls not started - listening - SyncStrategy - internal decoder>
DEBUG:ldap3:BASIC:done EXTENDED operation, result <False>
```

* Update README.md