### PR TITLE
Removed the upper version bound of LDAP version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,5 +8,5 @@ setup(
     description="LDAP Authentication Plugin for Radicale 2",
     author="Raoul Thill",
     license="GNU GPL v3",
-    install_requires=["radicale >= 2.0", "ldap3 >= 2.3, < 2.4"],
+    install_requires=["radicale >= 2.0", "ldap3 >= 2.3"],
     packages=["radicale_auth_ldap"])


### PR DESCRIPTION
This resolve:
- LDAP3 version #6
- Failed to load authentication module 'radicale_auth_ldap': invalid syntax (connection.py, line 55) #9