### PR TITLE
Support for multiple LDAP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ You will need to set a few options inside your radicale config file. Example:
 [auth]
 type = radicale_auth_ldap
 
-# LDAP server URL, with protocol and port
+# LDAP server URL, with protocol and port (multiple servers can be separated by spaces)
 ldap_url = ldap://ldap:389
 
 # LDAP base path

--- a/radicale_auth_ldap/__init__.py
+++ b/radicale_auth_ldap/__init__.py
@@ -38,14 +38,14 @@ class Auth(BaseAuth):
     def is_authenticated(self, user, password):
         """Check if ``user``/``password`` couple is valid."""
         server_list = self.configuration.get("auth", "ldap_url")
-        self.logger.info("Server list type: %s" % type(server_list))
-        self.logger.info("Server list: %s" % server_list)
+        self.logger.warn("Server list type: %s" % type(server_list))
+        self.logger.warn("Server list: %s" % server_list)
         if ' ' in server_list:  # Handle for multiple LDAP server defined in ldap_url with space separation
-            self.logger.info("Server list contains multiple servers")
+            self.logger.warn("Server list contains multiple servers")
             servers = server_list.split(' ')
             SERVER = ldap3.ServerPool(None)
-            self.logger.info("Servers type: %s" % type(serverst))
-            self.logger.info("Servers: %s" % servers)
+            self.logger.warn("Servers type: %s" % type(servers))
+            self.logger.warn("Servers: %s" % servers)
             for s in servers:
                 SERVER.add(ldap3.Server(s))
         else:  # only one server is defined

--- a/radicale_auth_ldap/__init__.py
+++ b/radicale_auth_ldap/__init__.py
@@ -37,19 +37,16 @@ import radicale_auth_ldap.ldap3imports
 class Auth(BaseAuth):
     def is_authenticated(self, user, password):
         """Check if ``user``/``password`` couple is valid."""
-        server_list = self.configuration.get("auth", "ldap_url")
-        self.logger.warn("Server list type: %s" % type(server_list))
-        self.logger.warn("Server list: %s" % server_list)
-        if ' ' in server_list:  # Handle for multiple LDAP server defined in ldap_url with space separation
-            self.logger.warn("Server list contains multiple servers")
-            servers = server_list.split(' ')
+        servers = self.configuration.get("auth", "ldap_url")
+        if ' ' in servers:  # Handle for multiple LDAP server defined in ldap_url with space separation
+            servers = servers.split(' ')
+            self.logger.debug("Multiple servers: %s" % servers)
             SERVER = ldap3.ServerPool(None)
-            self.logger.warn("Servers type: %s" % type(servers))
-            self.logger.warn("Servers: %s" % servers)
             for s in servers:
                 SERVER.add(ldap3.Server(s))
         else:  # only one server is defined
-            SERVER = ldap3.Server(server_list)
+            self.logger.debug("Single server: %s" % servers)
+            SERVER = ldap3.Server(servers)
         BASE = self.configuration.get("auth", "ldap_base")
         ATTRIBUTE = self.configuration.get("auth", "ldap_attribute")
         FILTER = self.configuration.get("auth", "ldap_filter")

--- a/radicale_auth_ldap/__init__.py
+++ b/radicale_auth_ldap/__init__.py
@@ -38,9 +38,14 @@ class Auth(BaseAuth):
     def is_authenticated(self, user, password):
         """Check if ``user``/``password`` couple is valid."""
         server_list = self.configuration.get("auth", "ldap_url")
+        self.logger.info("Server list type: %s" % type(server_list))
+        self.logger.info("Server list: %s" % server_list)
         if ' ' in server_list:  # Handle for multiple LDAP server defined in ldap_url with space separation
+            self.logger.info("Server list contains multiple servers")
             servers = server_list.split(' ')
             SERVER = ldap3.ServerPool(None)
+            self.logger.info("Servers type: %s" % type(serverst))
+            self.logger.info("Servers: %s" % servers)
             for s in servers:
                 SERVER.add(ldap3.Server(s))
         else:  # only one server is defined

--- a/radicale_auth_ldap/__init__.py
+++ b/radicale_auth_ldap/__init__.py
@@ -45,6 +45,9 @@ class Auth(BaseAuth):
         PASSWORD = self.configuration.get("auth", "ldap_password")
         SCOPE = self.configuration.get("auth", "ldap_scope")
         SUPPORT_EXTENDED = self.configuration.getboolean("auth", "ldap_support_extended", fallback=True)
+
+        if ' ' in SERVER:  # Handle if multiple LDAP server is defined in ldap_url with space separation
+            SERVER = SERVER.split(' ')  # ldap3.connection can handle multiple servers in a list as an implicit server pool
         
         if BINDDN and PASSWORD:
             conn = ldap3.Connection(SERVER, BINDDN, PASSWORD)


### PR DESCRIPTION
Hi,

we are using Radicale with ldap auth, and we have multiple LDAP servers for HA. This modification let us automatically switch between the servers if one is down (using the ldap3 ServerPool concept). Please merge it if you find it potentially useful for others.